### PR TITLE
Fix Column Name Typo

### DIFF
--- a/main.py
+++ b/main.py
@@ -206,7 +206,7 @@ def replace_aliases(df_teams: pd.DataFrame, df_games: pd.DataFrame, df_teams_at_
     :param df_games: DataFrame with all games and their tournament, date, teams, and scores
     :param df_teams_at_tournaments: DataFrame of 0/1 with teams as indices and tournaments as columns
     """
-    for team, aliases in zip(df_teams["Teams"], df_teams["Aliases"]):
+    for team, aliases in zip(df_teams["Team"], df_teams["Aliases"]):
         if not pd.isna(aliases):
             df_games["Team_1"] = df_games["Team_1"].apply(lambda x: team if x in aliases else x)
             df_games["Team_2"] = df_games["Team_2"].apply(lambda x: team if x in aliases else x)


### PR DESCRIPTION
Running
❯ python main.py --input input_eufonly_2023 --season 2023 --date 2024-02-07 --output output_eufonly_2023
causes an error like this:
```
ranking.data_preparation - INFO - Preparing data for season 2023, mixed division.
ranking.data_preparation - INFO - 107 teams defined for the mixed division.
ranking.data_preparation - INFO - 253 raw games found for the mixed division.
Traceback (most recent call last):
  File "/Users/gruschm/projects/Ranking/venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3803, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5745, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5753, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'Teams'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/gruschm/projects/Ranking/main.py", line 281, in <module>
    main()
  File "/Users/gruschm/projects/Ranking/main.py", line 87, in main
    prepare_data(args.input, args.season, divisions, prep_output_path)
  File "/Users/gruschm/projects/Ranking/main.py", line 140, in prepare_data
    replace_aliases(df_teams, df_games, df_teams_at_tournaments)
  File "/Users/gruschm/projects/Ranking/main.py", line 209, in replace_aliases
    for team, aliases in zip(df_teams["Teams"], df_teams["Aliases"]):
                             ~~~~~~~~^^^^^^^^^
  File "/Users/gruschm/projects/Ranking/venv/lib/python3.11/site-packages/pandas/core/frame.py", line 3805, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gruschm/projects/Ranking/venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3805, in get_loc
    raise KeyError(key) from err
KeyError: 'Teams'
```

This merge request fixes the typo.